### PR TITLE
Add invite message to new user event

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -32,7 +32,7 @@ const eventResponses = {
       text: `:new: user_added
 
 <@${event.user.id}> さん、 エンジニアの登壇を応援する会の Slack へようこそ :smile:
-<#${event.channel.id}> で自己紹介をお願いします。
+自己紹介をお願いします。
 また、以下の参加ガイドをご確認ください :pray:
 
 https:\/\/esa-pages.io\/p\/sharing\/10407\/posts\/320\/0bb2faf43a53b3226482.html`,

--- a/src/events.js
+++ b/src/events.js
@@ -28,8 +28,14 @@ const eventResponses = {
   },
   'team_join': async (event, client) => {
     return client.chat.postMessage({
-      channel: 'feed',
-      text: `user_added: <@${event.user.id}>`,
+      channel: '自己紹介',
+      text: `:new: user_added
+
+<@${event.user.id}> さん、 エンジニアの登壇を応援する会の Slack へようこそ :smile:
+<#${event.channel.id}> で自己紹介をお願いします。
+また、以下の参加ガイドをご確認ください :pray:
+
+https:\/\/esa-pages.io\/p\/sharing\/10407\/posts\/320\/0bb2faf43a53b3226482.html`,
     })
   },
   'channel_created': async (event, client) => {


### PR DESCRIPTION
## 目的
今まで、手動で新規訪問者への通知を行っていたが、運用効率化のために自動化する。

## 変更内容
* ユーザー新規追加の通知メッセージ先を `自己紹介` channel に変更する
* ユーザー新規追加の通知メッセージに自己紹介の依頼、参加ガイドの閲覧依頼の文言を追加する

### メッセージ内容

```
:new: user_added

@hoge さん、 エンジニアの登壇を応援する会の Slack へようこそ :smile:
自己紹介をお願いします。
また、以下の参加ガイドをご確認ください :pray:

https://esa-pages.io/p/sharing/10407/posts/320/0bb2faf43a53b3226482.html
```

です。

`@hoge` => 新規のユーザーへの通知

オンボーディング的に Slack に参加する人がはじめに確認するメッセージなので、人間味のある内容にした上で、好意の感情と依頼の感情を Emoji で追加しました。

## 関連情報
* [運営/メンバーオンボーディング/課題/Slack参入後の参加者案内を行う - engineers.esa.io](https://engineers.esa.io/posts/190)